### PR TITLE
[Picopass] Force ISO15693 1OutOf4 mode

### DIFF
--- a/picopass/protocol/picopass_listener.c
+++ b/picopass/protocol/picopass_listener.c
@@ -752,6 +752,7 @@ void picopass_listener_start(
     instance->context = context;
 
     picopass_listener_reset(instance);
+    nfc_iso15693_force_1outof4(instance->nfc);
     nfc_start(instance->nfc, picopass_listener_start_callback, instance);
 }
 

--- a/picopass/protocol/picopass_poller.c
+++ b/picopass/protocol/picopass_poller.c
@@ -671,7 +671,6 @@ void picopass_poller_start(
     instance->context = context;
 
     instance->session_state = PicopassPollerSessionStateActive;
-    nfc_iso15693_force_1outof4(instance->nfc);
     nfc_start(instance->nfc, picopass_poller_callback, instance);
 }
 

--- a/picopass/protocol/picopass_poller.c
+++ b/picopass/protocol/picopass_poller.c
@@ -671,6 +671,7 @@ void picopass_poller_start(
     instance->context = context;
 
     instance->session_state = PicopassPollerSessionStateActive;
+    nfc_iso15693_force_1outof4(instance->nfc);
     nfc_start(instance->nfc, picopass_poller_callback, instance);
 }
 


### PR DESCRIPTION
This uses the new APIs in Next-Flip/Momentum-Firmware#225 to disable mode autodetection, preventing issues caused by misdetection (flipperdevices/flipperzero-good-faps#105 seems to be an example of misdetection causing a crash).