### PR TITLE
Nightstand clock fixes

### DIFF
--- a/nightstand_clock/clock_app.c
+++ b/nightstand_clock/clock_app.c
@@ -52,7 +52,7 @@ static const NotificationSequence led_reset = {
 
 void set_backlight_brightness(float brightness) {
     notif->settings.display_brightness = brightness;
-    notification_message(notif, &sequence_display_backlight_on);
+    furi_hal_light_set(LightBacklight, brightness * 0xFF);
 }
 
 void handle_up() {
@@ -315,7 +315,6 @@ int32_t clock_app(void* p) {
     float tmpBrightness = notif->settings.display_brightness;
     brightness = tmpBrightness * 100; // Keep current brightness by default
 
-    notification_message(notif, &sequence_display_backlight_enforce_on);
     notification_message(notif, &led_off);
 
     // Set system callbacks
@@ -395,7 +394,6 @@ int32_t clock_app(void* p) {
     free(plugin_state);
 
     set_backlight_brightness(tmpBrightness);
-    notification_message(notif, &sequence_display_backlight_enforce_auto);
     notification_message(notif, &led_reset);
 
     return 0;

--- a/nightstand_clock/clock_app.c
+++ b/nightstand_clock/clock_app.c
@@ -396,5 +396,16 @@ int32_t clock_app(void* p) {
     set_backlight_brightness(tmpBrightness);
     notification_message(notif, &led_reset);
 
+    // Force RGB backlight update to restore original color settings
+    // by temporarily changing brightness and restoring it
+    if(momentum_settings.rgb_backlight) {
+        uint8_t current_brightness = tmpBrightness * 0xFF;
+        // Temporarily set brightness to 0 to force update
+        furi_hal_light_set(LightBacklight, 0);
+        furi_delay_ms(10); // Small delay to ensure the change takes effect
+        // Restore original brightness
+        furi_hal_light_set(LightBacklight, current_brightness);
+    }
+
     return 0;
 }


### PR DESCRIPTION
Fixes a few bugs where pressing up on the dpad while in the nightstand clock resets rgb backlight color, and also fixes the issue when backing out of the app returning to the main menu

Also have vibro turned on for button presses which may have contributed to the symptoms.